### PR TITLE
feat: Add squash options to PullRequest merge for Gitlab

### DIFF
--- a/scm/driver/gitlab/pr.go
+++ b/scm/driver/gitlab/pr.go
@@ -337,6 +337,9 @@ type prInput struct {
 
 type pullRequestMergeRequest struct {
 	CommitMessage             string `json:"merge_commit_message,omitempty"`
+	SquashCommitMessage       string `json:"squash_commit_message,omitempty"`
+	Squash                    string `json:"squash,omitempty"`
+	RemoveSourceBranch        string `json:"should_remove_source_branch,omitempty"`
 	SHA                       string `json:"sha,omitempty"`
 	MergeWhenPipelineSucceeds string `json:"merge_when_pipeline_succeeds,omitempty"`
 }

--- a/scm/driver/gitlab/util.go
+++ b/scm/driver/gitlab/util.go
@@ -127,12 +127,24 @@ func encodePullRequestMergeOptions(opts *scm.PullRequestMergeOptions) *pullReque
 		if opts.SHA != "" {
 			prRequest.SHA = opts.SHA
 		}
+		switch opts.MergeMethod {
+		case "squash":
+			if opts.CommitTitle != "" {
+				prRequest.SquashCommitMessage = opts.CommitTitle
+			}
+			prRequest.Squash = "true"
+		default:
+			if opts.CommitTitle != "" {
+				prRequest.CommitMessage = opts.CommitTitle
+			}
+		}
 		if opts.MergeWhenPipelineSucceeds {
 			prRequest.MergeWhenPipelineSucceeds = "true"
 		}
-		if opts.CommitTitle != "" {
-			prRequest.CommitMessage = opts.CommitTitle
+		if opts.DeleteSourceBranch {
+			prRequest.RemoveSourceBranch = "true"
 		}
+
 	}
 	return prRequest
 }

--- a/scm/pr.go
+++ b/scm/pr.go
@@ -112,6 +112,9 @@ type (
 
 		// Merge automatically once the pipeline completes. (Supported only in gitlab)
 		MergeWhenPipelineSucceeds bool
+
+		// Signals to the SCM to remove the source branch during merge
+		DeleteSourceBranch bool
 	}
 
 	// PullRequestService provides access to pull request resources.


### PR DESCRIPTION
When doing a Merge API Request there are a few options that Gitlab provides
which can be very useful. Another change in this PR allows to squash during merge.
This behaviour was not consistent with the current scm.PullRequestMergeOptions
and here it is adjusted to work as expected